### PR TITLE
This commit adds a feature to prevent the bot from responding to mess…

### DIFF
--- a/configurations/user_whatsapp.json
+++ b/configurations/user_whatsapp.json
@@ -4,7 +4,8 @@
     "vendor_name": "whatsAppBaileyes",
     "vendor_config": {
       "port": 8080,
-      "allow_group_messages": false
+      "allow_group_messages": false,
+      "process_offline_messages": false
     },
     "queue_config": {
       "max_messages": 100,

--- a/vendor/whatsAppBaileyes.py
+++ b/vendor/whatsAppBaileyes.py
@@ -3,6 +3,7 @@ import threading
 import subprocess
 import json
 import sys
+import base64
 from typing import Dict, Optional
 import urllib.request
 import urllib.error
@@ -37,10 +38,15 @@ class Vendor:
         # Start the Node.js server as a subprocess
         try:
             print(f"VENDOR ({self.user_id}): Starting Node.js server on port {self.port}...")
+
+            # Serialize and encode the config to pass as a command line argument
+            config_json = json.dumps(self.config)
+            config_base64 = base64.b64encode(config_json.encode('utf-8')).decode('utf-8')
+
             # We need to make sure the server script is found relative to the project root
             server_script = "vendor/whatsapp_baileys_server/server.js"
             self.node_process = subprocess.Popen(
-                ['node', server_script, str(self.port), self.user_id],
+                ['node', server_script, str(self.port), self.user_id, config_base64],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT
             )


### PR DESCRIPTION
…ages that were received while it was offline.

- A new `process_offline_messages` boolean option has been added to the `vendor_config`. The default is `false`.
- The `whatsAppBaileyes.py` vendor now passes the entire vendor configuration to the Node.js server as a base64-encoded argument.
- The Node.js server (`server.js`) now decodes this configuration. It compares incoming message timestamps against its own startup time and ignores any messages that are older if `process_offline_messages` is not `true`.