### PR TITLE
Fix homepage status display and logic

### DIFF
--- a/chat_providers/whatsapp_baileys_server/server.js
+++ b/chat_providers/whatsapp_baileys_server/server.js
@@ -80,8 +80,8 @@ async function connectToWhatsApp() {
             } catch (e) {
                 console.error('Error populating contacts cache from auth state:', e);
             }
-        } else {
-            connectionStatus = connection || 'waiting';
+        } else if (connection) {
+            connectionStatus = connection;
         }
 
         if (qr) {

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -159,6 +159,7 @@ function HomePage() {
       case 'linking':
       case 'initializing':
       case 'got qr code':
+      case 'waiting':
         return 'orange';
       case 'disconnected':
       case 'invalid_config':


### PR DESCRIPTION
This commit addresses two issues related to the status of user configurations on the homepage:

1.  **Frontend Color:** The 'waiting' status is now correctly displayed with an orange color, as intended. The 'waiting' case was missing from the `getStatusColor` function in `HomePage.js`.

2.  **Backend Status:** The backend logic in the Baileys WhatsApp provider has been corrected. Previously, the connection status could be incorrectly reset to 'waiting' even after a successful connection. This was due to the connection update handler not properly checking for the existence of a new connection state before updating. The logic is now more robust and only updates the status when a new state is explicitly provided.