### PR TITLE
Fix(schema): Allow null value for api_key in frontend validation

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,15 +111,6 @@ async def get_configuration_schema():
                     # This is the null choice
                     item['title'] = "Collection Only"
 
-    # Explicitly set the api_key to be a string to avoid type ambiguity on the frontend
-    if defs_key in schema and 'LLMProviderSettings' in schema[defs_key]:
-        api_key_schema = schema[defs_key]['LLMProviderSettings']['properties']['api_key']
-        # Pydantic's Optional[str] can become anyOf:[{type:'string'}, {type:'null'}]
-        # We simplify this to just a string type for the password widget.
-        if 'anyOf' in api_key_schema:
-            api_key_schema['type'] = 'string'
-            del api_key_schema['anyOf']
-
     return schema
 
 

--- a/test_main.py
+++ b/test_main.py
@@ -68,3 +68,19 @@ def test_save_array_configuration():
     assert isinstance(saved_data, list)
     assert len(saved_data) == 1
     assert saved_data[0]["user_id"] == "test_user_array"
+
+def test_get_configuration_schema_allows_null_api_key():
+    response = client.get("/api/configurations/schema")
+    assert response.status_code == 200
+    schema = response.json()
+
+    defs_key = '$defs' if '$defs' in schema else 'definitions'
+
+    llm_provider_settings = schema[defs_key]['LLMProviderSettings']
+    api_key_schema = llm_provider_settings['properties']['api_key']
+
+    assert 'anyOf' in api_key_schema
+
+    type_options = [item.get('type') for item in api_key_schema['anyOf']]
+    assert 'string' in type_options
+    assert 'null' in type_options


### PR DESCRIPTION
The frontend validation was failing when the `api_key` field was set to `null`. This was because the backend was explicitly modifying the JSON schema to only allow a string value for the `api_key`.

This change removes the schema modification in `main.py`, allowing the `api_key` to be either a string or null, as defined in the Pydantic model.

A test has been added to `test_main.py` to verify that the schema correctly allows for a null `api_key`.