### PR TITLE
Feat: Securely pass OpenAI API key to backend container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ configurations/*
 
 # Ignore root-level log files
 *.log
+
+# Ignore environment files
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./log:/app/log
     environment:
       - BAILEYS_SERVER_URL=http://baileys:3000
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
     depends_on:
       - baileys
     networks:


### PR DESCRIPTION
This change allows the `OPENAI_API_KEY` to be passed to the backend container at runtime without being hardcoded.

The `docker-compose.yml` file has been modified to read the `OPENAI_API_KEY` from the environment.

The `.gitignore` file has been updated to include the `.env` file, preventing accidental commits of secrets.

To use this, create a `.env` file in the project root with the following content: OPENAI_API_KEY=<YOUR_OPENAI_KEY>