### PR TITLE
fix: Differentiate between shutdown and unlink in session management

### DIFF
--- a/chatbot_manager.py
+++ b/chatbot_manager.py
@@ -178,15 +178,17 @@ class ChatbotInstance:
         self.provider_instance.start_listening()
         console_log(f"INSTANCE ({self.user_id}): System is running.")
 
-    def stop(self):
-        """Stops the provider listener gracefully and triggers the session end callback."""
+    def stop(self, cleanup_session: bool = False):
+        """
+        Stops the provider listener gracefully.
+
+        Args:
+            cleanup_session (bool): If True, instructs the provider to also clean up
+                                    the session data (e.g., on user unlink).
+        """
         if self.provider_instance:
-            console_log(f"INSTANCE ({self.user_id}): Shutting down...")
-            self.provider_instance.stop_listening()
-            # The provider's stop_listening should be responsible for calling the on_session_end
-            # callback to handle all session end cases (clean and unclean).
-            # However, as a fallback, we can call it here if the provider doesn't.
-            # For now, let's assume the provider handles it.
+            console_log(f"INSTANCE ({self.user_id}): Shutting down... (cleanup={cleanup_session})")
+            self.provider_instance.stop_listening(cleanup_session=cleanup_session)
             console_log(f"INSTANCE ({self.user_id}): Shutdown complete.")
 
     def get_status(self):


### PR DESCRIPTION
This commit fixes a critical bug where session files were being deleted on graceful shutdown (Ctrl+C).

The 'stop' logic was previously the same for both server shutdown and explicit user unlinking, causing session data to be wiped unintentionally.

This has been fixed by introducing a `cleanup_session` boolean flag throughout the call stack:

- `whatsAppBaileyes.py`: `stop_listening` now only sends a DELETE request to the session server if `cleanup_session=True`.
- `chatbot_manager.py`: `ChatbotInstance.stop` now accepts the flag and passes it down to the provider.
- `main.py`: The API now calls `instance.stop(cleanup_session=True)` for the `unlink_chatbot` endpoint, and `instance.stop(cleanup_session=False)` during the server `shutdown` event.

This ensures that sessions are correctly persisted across application restarts.